### PR TITLE
Add class properties for post, show_on_front, and page_for_posts

### DIFF
--- a/class-json-ld-breadcrumbs.php
+++ b/class-json-ld-breadcrumbs.php
@@ -42,6 +42,30 @@ if ( ! class_exists( 'JSON_LD_Breadcrumbs' ) ) {
 		private $crumbs = array();
 
 		/**
+		 * Current post object.
+		 *
+		 * @since  1.1.0
+		 * @var null|WP_Post
+		 */
+		private $post = null;
+
+		/**
+		 * Show on front option.
+		 *
+		 * @since  1.1.0
+		 * @var string
+		 */
+		private $show_on_front = '';
+
+		/**
+		 * Page for posts option.
+		 *
+		 * @since  1.1.0
+		 * @var int
+		 */
+		private $page_for_posts = 0;
+
+		/**
 		 * Initiate the class JSON_LD_Breadcrumbs
 		 *
 		 * @since  1.0.0

--- a/class-json-ld-breadcrumbs.php
+++ b/class-json-ld-breadcrumbs.php
@@ -61,7 +61,7 @@ if ( ! class_exists( 'JSON_LD_Breadcrumbs' ) ) {
 		 * Page for posts option.
 		 *
 		 * @since  1.1.0
-		 * @var int
+		 * @var integer
 		 */
 		private $page_for_posts = 0;
 
@@ -87,7 +87,7 @@ if ( ! class_exists( 'JSON_LD_Breadcrumbs' ) ) {
 		private function __construct() {
 			$this->post           = ( isset( $GLOBALS['post'] ) ? $GLOBALS['post'] : null );
 			$this->show_on_front  = get_option( 'show_on_front' );
-			$this->page_for_posts = get_option( 'page_for_posts' );
+			$this->page_for_posts = (int) get_option( 'page_for_posts' );
 
 			add_action( 'wp_head', array( $this, 'set_crumbs' ) );
 		}


### PR DESCRIPTION
## Summary
- Adds three new class properties to `JSON_LD_Breadcrumbs`: `$post`, `$show_on_front`, and `$page_for_posts`
- These properties store the current post object, the "show on front" option, and the "page for posts" option respectively
- Includes proper PHPDoc annotations with `@since 1.1.0` tags

## Test plan
- [ ] Verify the plugin activates without errors
- [ ] Confirm breadcrumb JSON-LD output remains unchanged on various page types (posts, pages, archives)
- [ ] Check that no PHP notices or warnings are introduced